### PR TITLE
feat: Dockerize the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,38 @@
 
 A working application application of the [postman2mcp](https://github.com/gegedenice/postman2mcp) module
 
+## Running with Docker
+
+This repository is dockerized for easy setup and deployment. The two services (FastAPI and FastMCP) are managed using `docker-compose`.
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+### Usage
+
+1. **Build and start the services:**
+
+   ```bash
+   docker-compose up --build
+   ```
+
+   This command will build the Docker image for the services and start them. The `-d` flag can be used to run the services in detached mode.
+
+2. **Access the services:**
+
+   - **FastAPI server:** `http://localhost:8000`
+   - **FastMCP server:** `http://localhost:3333/mcp`
+
+3. **Stopping the services:**
+
+   To stop the services, press `Ctrl+C` in the terminal where `docker-compose` is running, or run the following command from the project root:
+
+   ```bash
+   docker-compose down
+   ```
+
 ---
 
 ## How was the project generated

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  fastapi:
+    build:
+      context: ./gen-openalex-postman2mcp
+    ports:
+      - "8000:8000"
+    command: uvicorn fastapi_proxy.main:app --host 0.0.0.0 --port 8000
+
+  fastmcp:
+    build:
+      context: ./gen-openalex-postman2mcp
+    ports:
+      - "3333:3333"
+    depends_on:
+      - fastapi
+    command: ["./wait-for-it.sh", "fastapi:8000", "--", "python", "server.py"]

--- a/gen-openalex-postman2mcp/Dockerfile
+++ b/gen-openalex-postman2mcp/Dockerfile
@@ -1,0 +1,22 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN apt-get update && apt-get install -y netcat-openbsd && \
+    pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application's code into the container
+COPY . .
+
+# Make wait-for-it.sh executable
+RUN chmod +x wait-for-it.sh
+
+# Expose ports
+EXPOSE 8000
+EXPOSE 3333

--- a/gen-openalex-postman2mcp/wait-for-it.sh
+++ b/gen-openalex-postman2mcp/wait-for-it.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# wait-for-it.sh: wait for a host and port to be available before executing a command
+
+set -e
+
+host="$1"
+shift
+cmd="$@"
+
+until nc -z "$host" 8000; do
+  >&2 echo "FastAPI is unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "FastAPI is up - executing command"
+exec $cmd


### PR DESCRIPTION
This commit dockerizes the application by adding a Dockerfile and a docker-compose.yml file.

The docker-compose.yml file defines two services:
- fastapi: builds and runs the FastAPI server on port 8000.
- fastmcp: builds and runs the FastMCP server on port 3333.

A wait-for-it.sh script is used to ensure the fastmcp service waits for the fastapi service to be available before starting.

The README.md has been updated with instructions on how to run the application using Docker.